### PR TITLE
[FIX] Removed Blade::setEscapedContentTags and Blade::setContentTags …

### DIFF
--- a/src/Jlapp/Swaggervel/routes.php
+++ b/src/Jlapp/Swaggervel/routes.php
@@ -48,9 +48,6 @@ Route::get(Config::get('swaggervel.api-docs-route'), function() {
         Request::setTrustedProxies(array($proxy));
     }
 
-    Blade::setEscapedContentTags('{{{', '}}}');
-    Blade::setContentTags('{{', '}}');
-
     //need the / at the end to avoid CORS errors on Homestead systems.
     $response = response()->view('swaggervel::index', array(
         'secure'         => Request::secure(),


### PR DESCRIPTION
…calls which no longer exists on Laravel 5.4

Fixes #2 