### PR TITLE
Relative paths fix in config, caused by ca8a84a, fixes #22, closes #21

### DIFF
--- a/src/config/swaggervel.php
+++ b/src/config/swaggervel.php
@@ -13,14 +13,14 @@ return [
       | Relative path to access parsed swagger annotations.
       |--------------------------------------------------------------------------
     */
-    'doc-route' => 'docs',
+    'doc-route' => '/docs',
 
     /*
       |--------------------------------------------------------------------------
       | Relative path to access public UI resources.
       |--------------------------------------------------------------------------
      */
-    'ui-resource-path' => 'vendor/swaggervel',
+    'ui-resource-path' => '/vendor/swaggervel',
 
     /*
       |--------------------------------------------------------------------------
@@ -34,7 +34,7 @@ return [
       | Relative path to access swagger ui.
       |--------------------------------------------------------------------------
     */
-    'api-docs-route' => 'api/docs',
+    'api-docs-route' => '/api/docs',
 
     /*
       |--------------------------------------------------------------------------


### PR DESCRIPTION
This issue was causing blank page on route `/api/docs` because of wrong paths resolution - throws in browser console: `Uncaught ReferenceError: SwaggerUIBundle is not defined`