### PR TITLE
Update zircote/swagger-php to 3 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.6.0",
         "illuminate/support": "^5.0|^6.0",
         "swagger-api/swagger-ui": "^3.1",
-        "zircote/swagger-php": "^2.0"
+        "zircote/swagger-php": "^3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Update zircote/swagger-php to version 3.0 that supports php 7.4

Now when using php 7.4 got error: 

Trying to access array offset on value of type bool at /var/www/app/vendor/zircote/swagger-php/src/StaticAnalyser.php:278)